### PR TITLE
31208-Mango-Http-List-Indexes

### DIFF
--- a/src/mango_act_idx_list.erl
+++ b/src/mango_act_idx_list.erl
@@ -8,13 +8,40 @@
 ]).
 
 
-init(_Db, {_Props}) ->
-    ok.
+init(Db, {Props}) ->
+    {ok, Opts} = mango_opts:validate(Props, opts()),
+    [<<"list_indexes">>] =Opts.
 
+run(Resp, Db, St) ->
+    Result = format_results(Db),
+    {ok, {[
+        {ok, true},
+        {result, {Result}}
+    ]}}.
 
-run(_Resp, _Db, _St) ->
-    ok.
-
-
+format_results(Db) ->
+    Indexes = mango_index:list(Db),    
+    Result= lists:flatmap(fun(Idx) ->
+    IndexSize=mango_index:get_index_size(element(2,Idx),element(3,Idx)), 
+    case element(6,Idx) of
+        all_docs ->
+        IdxInfo = {[{<<"fields">>,<<"all_docs">>},{<<"ddocid">>,element(3,Idx)}, {<<"disk_size">>,<<"N/A">>}]};
+        _ ->    
+        {Fields} = element(6,Idx),
+        IdxInfo = {Fields ++ [{<<"ddocid">>,element(3,Idx)}] ++ [IndexSize]}  
+    end,
+    [{element(4,Idx),IdxInfo
+    }] end, Indexes),
+    Result.
+   
 format_error(Else) ->
     mango_util:fmt("Unknown error: ~p", [Else]).
+
+opts() ->
+    [
+        {<<"action">>, [
+            {assert, <<"list_indexes">>}
+        ]}
+    ].
+
+

--- a/src/mango_index.erl
+++ b/src/mango_index.erl
@@ -4,7 +4,8 @@
 -export([
     create/3,
     list/1,
-    delete/3
+    delete/3,
+    get_index_size/2
 ]).
 
 
@@ -28,7 +29,6 @@ create(Db, Index, Opts) ->
             end
     end.
 
-
 list(Db) ->
     {ok, DDocs0} = mango_util:open_ddocs(Db),
     Pred = fun({Props}) ->
@@ -43,10 +43,16 @@ list(Db) ->
         mango_idx:from_ddoc(Db, Doc)
     end, DDocs).
 
-
 delete(_Db, _DDocId, _IndexName) ->
     ok.
 
+get_index_size(Db,DDocId) ->
+    case DDocId of
+        undefined -> DiskSize={<<"size">>,<<"N/A">>};
+        _ -> 
+        {ok,[_,_,_,_,_,_,_,DiskSize | Rest]}=fabric:get_view_group_info(Db,DDocId)
+    end,
+    DiskSize.
 
 load_ddoc(Db, DDocId) ->
     case mango_util:open_doc(Db, DDocId) of


### PR DESCRIPTION
Returns a list of indexes with relevant information. It is determined from fabric's get view info's disk_size field.
