### PR TITLE
Optimize field filters

### DIFF
--- a/src/mango_doc.erl
+++ b/src/mango_doc.erl
@@ -10,6 +10,7 @@
 
     get_field/2,
     get_field/3,
+    parse_field/1,
     rem_field/2,
     set_field/3
 ]).

--- a/src/mango_fields.erl
+++ b/src/mango_fields.erl
@@ -23,13 +23,14 @@ extract(Doc, all_fields) ->
     Doc;
 extract(Doc, Fields) ->
     lists:foldl(fun(F, NewDoc) ->
-        case mango_doc:get_field(Doc, F) of
+        {ok, Path} = mango_doc:parse_field(F),
+        case mango_doc:get_field(Doc, Path) of
             not_found ->
                 NewDoc;
             bad_path ->
                 NewDoc;
             Value ->
-                mango_doc:set_field(NewDoc, F, Value)
+                mango_doc:set_field(NewDoc, Path, Value)
         end
     end, {[]}, Fields).
 


### PR DESCRIPTION
The first patch in this set makes the `parse_field` function much faster in the case where the user-supplied field name does not have any escaped characters. The second patch halves the number of invocations of the `parse_field` function.
