### PR TITLE
Add Empty Clause For Start End Key

### DIFF
--- a/src/mango_idx_view.erl
+++ b/src/mango_idx_view.erl
@@ -92,6 +92,8 @@ columns(Idx) ->
 
 start_key([]) ->
     [];
+start_key([empty]) ->
+    [];
 start_key([{'$gt', Key, _, _} | Rest]) ->
     case mango_json:special(Key) of
         true ->
@@ -108,6 +110,8 @@ start_key([{'$eq', Key, '$eq', Key} | Rest]) ->
 
 
 end_key([]) ->
+    [{[]}];
+end_key([empty]) ->
     [{[]}];
 end_key([{_, _, '$lt', Key} | Rest]) ->
     case mango_json:special(Key) of


### PR DESCRIPTION
Add [empty] clause for functions start_key and end_key
in mango_idx_view.erl.

36579-empty-start-end-key