### PR TITLE
Always use the DB name as the cache key

### DIFF
--- a/src/mango_idx.erl
+++ b/src/mango_idx.erl
@@ -37,7 +37,7 @@
 
 
 list(Db) ->
-    {ok, Indexes} = ddoc_cache:open(Db, ?MODULE),
+    {ok, Indexes} = ddoc_cache:open(db_to_name(Db), ?MODULE),
     Indexes.
 
 recover(Db) ->


### PR DESCRIPTION
`mango_idx:list/1` accepts a `#db{}` in addition to a database name. When the former is used it's often a stub record with a randomly generated UUID in the `#db_header`. This really kills the cache hit rate ;)

BugzID: 42707
