### PR TITLE
Fix text sort desc

### DIFF
--- a/src/mango_cursor_text.erl
+++ b/src/mango_cursor_text.erl
@@ -204,12 +204,18 @@ apply_user_fun(CAcc, Doc) ->
 sort_query(Opts, Selector) ->
     {sort, {Sort}} = lists:keyfind(sort, 1, Opts),
     SortList = lists:map(fun(SortField) ->
-        RawSortField = case SortField of
-            {Field, <<"asc">>} -> Field;
-            {Field, <<"desc">>} -> <<"-", Field/binary>>;
-            Field when is_binary(Field) -> Field
+        {Dir, RawSortField}  = case SortField of
+            {Field, <<"asc">>} -> {asc, Field};
+            {Field, <<"desc">>} -> {desc, Field};
+            Field when is_binary(Field) -> {asc, Field}
         end,
-        mango_selector_text:append_sort_type(RawSortField, Selector)
+        SField = mango_selector_text:append_sort_type(RawSortField, Selector),
+        case Dir of
+            asc ->
+                SField;
+            desc ->
+                <<"-", SField/binary>>
+        end
     end, Sort),
     case SortList of
         [] -> relevance;

--- a/test/09-text-sort-test.py
+++ b/test/09-text-sort-test.py
@@ -21,6 +21,17 @@ class SortTests(mango.UserDocsTextTests):
         assert len(docs) == 15
         assert docs[0]["age"] == 22
 
+    def test_number_sort_desc(self):
+        q = {"age": {"$gt": 0}}
+        docs = self.db.find(q, sort=[{"age": "desc"}])
+        assert len(docs) == 15
+        assert docs[0]["age"] == 79
+
+        q = {"manager": True}
+        docs = self.db.find(q, sort=[{"age:number": "desc"}])
+        assert len(docs) == 11
+        assert docs[0]["age"] == 79
+
     def test_string_sort(self):
         q = {"email": {"$gt": None}}
         docs = self.db.find(q, sort=["email:string"])


### PR DESCRIPTION
Call append_sort_type on field name before appending "-" when the sort
is descending.

43531-mango-text-sort-desc