### PR TITLE
Fix Field Exists Function

### DIFF
--- a/src/mango_selector_text.erl
+++ b/src/mango_selector_text.erl
@@ -143,6 +143,10 @@ convert(Path, {[{<<"$type">>, _}]}) ->
 convert(Path, {[{<<"$mod">>, _}]}) ->
     field_exists_query(Path, "number");
 
+% The lucene regular expression engine does not use java's regex engine but
+% instead a custom implementation. The syntax is therefore different, so we do
+% would get different behavior than our view indexes. To be consistent, we will
+% simply return docs for fields that exist and then run our match filter.
 convert(Path, {[{<<"$regex">>, _}]}) ->
     field_exists_query(Path, "string");
 
@@ -260,7 +264,7 @@ field_exists_query(Path) ->
 
 
 field_exists_query(Path, Type) ->
-    {op_fieldname, [path_str(Path), ":", Type]}.
+    {op_fieldname, {[path_str(Path), ":"], Type}}.
 
 
 path_str(Path) ->

--- a/test/06-basic-text-test.py
+++ b/test/06-basic-text-test.py
@@ -375,6 +375,15 @@ class BasicTextTests(mango.UserDocsTextTests):
         docs = self.db.find(q)
         assert len(docs) == 1
 
+    def test_regex(self):
+        docs = self.db.find({
+                "age": {"$gt": 40},
+                "location.state": {"$regex": "(?i)new.*"}
+            })
+        assert len(docs) == 2
+        assert docs[0]["user_id"] == 2
+        assert docs[1]["user_id"] == 10
+
     # test lucene syntax in $text
 
 


### PR DESCRIPTION
The mango_selector:field_exists_query/2 was incorrectly returning
the query. This change fixes this issue and consequently fixes operators
that depended on this function such as $regex, $mod, and $type.

FogzBugId: 45970