### PR TITLE
List Text Indexes Correctly

### DIFF
--- a/src/mango_idx_text.erl
+++ b/src/mango_idx_text.erl
@@ -139,11 +139,19 @@ def_to_json([]) ->
 def_to_json([{<<"fields">>, <<"all_fields">>} | Rest]) ->
     [{<<"fields">>, []} | def_to_json(Rest)];
 def_to_json([{fields, Fields} | Rest]) ->
-    [{<<"fields">>, mango_sort:to_json(Fields)} | def_to_json(Rest)];
+    [{<<"fields">>, fields_to_json(Fields)} | def_to_json(Rest)];
 def_to_json([{<<"fields">>, Fields} | Rest]) ->
-    [{<<"fields">>, mango_sort:to_json(Fields)} | def_to_json(Rest)];
+    [{<<"fields">>, fields_to_json(Fields)} | def_to_json(Rest)];
 def_to_json([{Key, Value} | Rest]) ->
     [{Key, Value} | def_to_json(Rest)].
+
+
+fields_to_json([]) ->
+    [];
+fields_to_json([{[{<<"name">>, Name}, {<<"type">>, Type}]} | Rest]) ->
+    [{[{Name, Type}]} | fields_to_json(Rest)];
+fields_to_json([{[{<<"type">>, Type}, {<<"name">>, Name}]} | Rest]) ->
+    [{[{Name, Type}]} | fields_to_json(Rest)].
 
 
 opts() ->

--- a/test/01-index-crud-test.py
+++ b/test/01-index-crud-test.py
@@ -192,3 +192,21 @@ class IndexCrudTests(mango.DbPerClass):
             assert e.response.status_code == 404
         else:
             raise AssertionError("bad index delete")
+
+    def test_create_text_idx(self):
+        fields = [
+            {"name":"stringidx", "type" : "string"},
+            {"name":"booleanidx", "type": "boolean"}
+        ]
+        ret = self.db.create_text_index(fields=fields, name="text_idx_01")
+        assert ret is True
+        for idx in self.db.list_indexes():
+            if idx["name"] != "text_idx_01":
+                continue
+            print idx["def"]
+            assert idx["def"]["fields"] == [
+                {"stringidx": "string"},
+                {"booleanidx": "boolean"}
+            ]
+            return
+        raise AssertionError("index not created")


### PR DESCRIPTION
Text indexes are created in the form of {"name": "fieldname",
"type":"datatype"}. This differs from view based indexes that
are in the form of {"field":"sortdirection"}. When presenting
the text index fields, we display for each field "fieldname":"datatype".

FogBugzID:46012