### PR TITLE
Correctly choose index type

### DIFF
--- a/src/mango_idx_view.erl
+++ b/src/mango_idx_view.erl
@@ -112,7 +112,25 @@ is_usable(Idx, Selector) ->
     % a member of the indexable fields of the selector.
     Columns = columns(Idx),
     Fields = indexable_fields(Selector),
-    lists:member(hd(Columns), Fields).
+    lists:member(hd(Columns), Fields) and not is_text_search(Selector).
+
+
+is_text_search({[]}) ->
+    false;
+is_text_search({[{<<"$default">>, _}]}) ->
+    true;
+is_text_search({[{_Field, Cond}]}) when is_list(Cond) ->
+    lists:foldl(fun(C, Exists) ->
+        Exists or is_text_search(C)
+    end, false, Cond);
+is_text_search({[{_Field, Cond}]}) when is_tuple(Cond) ->
+    is_text_search(Cond);
+is_text_search({[{_Field, _Cond}]}) ->
+    false;
+%% we reached values, which should always be false
+is_text_search(Val)
+        when is_number(Val); is_boolean(Val); is_binary(Val)->
+    false.
 
 
 start_key([]) ->

--- a/test/05-index-selection-test.py
+++ b/test/05-index-selection-test.py
@@ -31,6 +31,14 @@ class IndexSelectionTests(mango.UserDocsTests):
             }, explain=True)
         assert resp["index"]["type"] == "json"
 
+    def test_with_text(self):
+        resp = self.db.find({
+                "$text" : "Stephanie",
+                "name.first": "Stephanie",
+                "name.last": "This doesn't have to match anything."
+            }, explain=True)
+        assert resp["index"]["type"] == "text"
+
     def test_no_view_index(self):
         resp = self.db.find({"name.first": "Ohai!"}, explain=True)
         assert resp["index"]["type"] == "text"


### PR DESCRIPTION
When users specify "$text" in the selector, json indexes should not be
used satisfy the query. We check the list of fields and look for
"$default". This implies that "$text" was used in the selector and
filter out all json indexes.

Fogbugzid: 46498