### PR TITLE
Also append quotes for specific numeric string field

### DIFF
--- a/src/mango_selector_text.erl
+++ b/src/mango_selector_text.erl
@@ -48,8 +48,7 @@ convert(Path, {[{<<"$default">>, Arg}]}) ->
 % The $text operator specifies a Lucene syntax query
 % so we just pull it in directly.
 convert(Path, {[{<<"$text">>, Query}]}) when is_binary(Query) ->
-    Value = maybe_append_quotes(value_str(Query)),
-    {op_field, {make_field(Path, Query), Value}};
+    {op_field, {make_field(Path, Query), value_str(Query)}};
 
 % The MongoDB docs for $all are super confusing and read more
 % like they screwed up the implementation of this operator
@@ -325,7 +324,12 @@ type_str(null) ->
 
 
 value_str(Value) when is_binary(Value) ->
-    mango_util:lucene_escape_query_value(Value);
+    case mango_util:is_number_string(Value) of
+        true ->
+            <<"\"", Value/binary, "\"">>;
+        false ->
+            mango_util:lucene_escape_query_value(Value)
+    end;
 value_str(Value) when is_integer(Value) ->
     list_to_binary(integer_to_list(Value));
 value_str(Value) when is_float(Value) ->
@@ -350,15 +354,6 @@ append_sort_type(RawSortField, Selector) ->
         _ ->
             Type = get_sort_type(RawSortField, Selector),
             <<EncodeField/binary, Type/binary>>
-    end.
-
-
-maybe_append_quotes(TextValue) ->
-    case mango_util:is_number_string(TextValue) of
-        true ->
-            <<"\"", TextValue/binary, "\"">>;
-        false ->
-            TextValue
     end.
 
 

--- a/test/06-basic-text-test.py
+++ b/test/06-basic-text-test.py
@@ -570,3 +570,10 @@ class NumStringTests(mango.NumStringDocsTextTests):
         docs = self.db.find(q)
         assert len(docs) == 1
         assert docs[0]["number_string"] == "Infinity"
+
+    def test_field_name_floating_point_val(self):
+        float_point_string = num_string_docs.DOCS[2]["number_string"]
+        q = {"number_string": float_point_string}
+        docs = self.db.find(q)
+        assert len(docs) == 1
+        assert docs[0]["number_string"] == float_point_string


### PR DESCRIPTION
We appended quotes for numeric_strings for $text. However, we did not
do this for specific fields. Note that we don't escape the field value
when it's a numeric string because that provides an incorrect string
value for clouseau.