### PR TITLE
Fix comparison operators

### DIFF
--- a/src/mango_selector_text.erl
+++ b/src/mango_selector_text.erl
@@ -267,13 +267,26 @@ make_field(Path, Arg) ->
 
 
 range(lt, Arg) ->
-    [<<"[-Infinity TO ">>, value_str(Arg), <<"}">>];
+    Min = get_range(min, Arg),
+    [<<"[", Min/binary, " TO ">>, value_str(Arg), <<"}">>];
 range(lte, Arg) ->
-    [<<"[-Infinity TO ">>, value_str(Arg), <<"]">>];
+    Min = get_range(min, Arg),
+    [<<"[", Min/binary, " TO ">>, value_str(Arg), <<"]">>];
 range(gte, Arg) ->
-    [<<"[">>, value_str(Arg), <<" TO Infinity]">>];
+    Max = get_range(max, Arg),
+    [<<"[">>, value_str(Arg), <<" TO ", Max/binary, "]">>];
 range(gt, Arg) ->
-    [<<"{">>, value_str(Arg), <<" TO Infinity]">>].
+    Max = get_range(max, Arg),
+    [<<"{">>, value_str(Arg), <<" TO ", Max/binary, "]">>].
+
+get_range(min, Arg) when is_number(Arg) ->
+    <<"-Infinity">>;
+get_range(min, _Arg) ->
+    <<"\"\"">>;
+get_range(max, Arg) when is_number(Arg) ->
+    <<"Infinity">>;
+get_range(max, _Arg) ->
+    <<"\u0x10FFFF">>.
 
 
 field_exists_query(Path) ->

--- a/test/06-basic-text-test.py
+++ b/test/06-basic-text-test.py
@@ -79,6 +79,10 @@ class BasicTextTests(mango.UserDocsTextTests):
         for d in docs:
             assert d["user_id"] in (1, 7, 9)
 
+        docs = self.db.find({"company": {"$lt": "Dreamia"}})
+        assert len(docs) == 1
+        assert docs[0]["company"] == "Affluex"
+
     def test_lte(self):
         docs = self.db.find({"age": {"$lte": 21}})
         assert len(docs) == 0
@@ -91,6 +95,11 @@ class BasicTextTests(mango.UserDocsTextTests):
         assert len(docs) == 3
         for d in docs:
             assert d["user_id"] in (1, 7, 9)
+
+        docs = self.db.find({"company": {"$lte": "Dreamia"}})
+        assert len(docs) == 2
+        for d in docs:
+            assert d["user_id"] in (0, 11)
 
     def test_eq(self):
         docs = self.db.find({"age": 21})
@@ -132,6 +141,9 @@ class BasicTextTests(mango.UserDocsTextTests):
         docs = self.db.find({"age": {"$gt": 79}})
         assert len(docs) == 0
 
+        docs = self.db.find({"company": {"$gt": "Zialactic"}})
+        assert len(docs) == 0
+
     def test_gte(self):
         docs = self.db.find({"age": {"$gte": 77}})
         assert len(docs) == 2
@@ -149,6 +161,10 @@ class BasicTextTests(mango.UserDocsTextTests):
 
         docs = self.db.find({"age": {"$gte": 80}})
         assert len(docs) == 0
+
+        docs = self.db.find({"company": {"$gte": "Zialactic"}})
+        assert len(docs) == 1
+        assert docs[0]["company"] == "Zialactic"
 
     def test_and(self):
         docs = self.db.find({"age": 22, "manager": True})


### PR DESCRIPTION
We appended quotes for numeric_strings for $text. However, we did not
do this for specific fields. Note that we don't escape the field value
when it's a numeric string because that provides an incorrect string
value for clouseau.