### PR TITLE
Provide an ability to disable the array length field

### DIFF
--- a/src/mango_native_proc.erl
+++ b/src/mango_native_proc.erl
@@ -151,7 +151,10 @@ get_text_entries0(IdxProps, Doc) ->
     DefaultEnabled = get_default_enabled(IdxProps),
     IndexArrayLengths = get_index_array_lengths(IdxProps),
     FieldsList = get_text_field_list(IdxProps),
-    TAcc = #tacc{index_array_lengths = IndexArrayLengths, fields = FieldsList},
+    TAcc = #tacc{
+        index_arrray_lengths = IndexArrayLengths,
+        fields = FieldsList
+    },
     Fields0 = get_text_field_values(Doc, TAcc),
     Fields = if not DefaultEnabled -> Fields0; true ->
         add_default_text_field(Fields0)
@@ -167,16 +170,17 @@ get_text_field_values({Props}, TAcc) when is_list(Props) ->
 get_text_field_values(Values, TAcc) when is_list(Values) ->
     IndexArrayLengths = TAcc#tacc.index_array_lengths,
     NewPath = ["[]" | TAcc#tacc.path],
-    NewTAcc = TAcc#tacc{index_array_lengths = IndexArrayLengths, path = NewPath},
+    NewTAcc = TAcc#tacc{path = NewPath},
     case IndexArrayLengths of 
         true ->
             % We bypass make_text_field and directly call make_text_field_name
             % because the length field name is not part of the path.
             LengthFieldName = make_text_field_name(NewTAcc#tacc.path, <<"length">>),
             LengthField = [{LengthFieldName, <<"length">>, length(Values)}],
-            get_text_field_values_arr(Values, NewTAcc,LengthField);
+            get_text_field_values_arr(Values, NewTAcc, LengthField);
+
         _ ->
-            get_text_field_values_arr(Values, NewTAcc,[])
+            get_text_field_values_arr(Values, NewTAcc, [])
     end;
 get_text_field_values(Bin, TAcc) when is_binary(Bin) ->
     make_text_field(TAcc, <<"string">>, Bin);
@@ -194,9 +198,8 @@ get_text_field_values(null, TAcc) ->
 get_text_field_values_obj([], _, FAcc) ->
     FAcc;
 get_text_field_values_obj([{Key, Val} | Rest], TAcc, FAcc) ->
-    IndexArrayLengths = TAcc#tacc.index_array_lengths,
     NewPath = [Key | TAcc#tacc.path],
-    NewTAcc = TAcc#tacc{index_array_lengths = IndexArrayLengths, path = NewPath},
+    NewTAcc = TAcc#tacc{path = NewPath},
     Fields = get_text_field_values(Val, NewTAcc),
     get_text_field_values_obj(Rest, TAcc, Fields ++ FAcc).
 
@@ -218,8 +221,10 @@ get_default_enabled(Props) ->
             couch_util:get_value(<<"enabled">>, Opts, true)
     end.
 
+
 get_index_array_lengths(Props) ->
     couch_util:get_value(<<"index_array_lengths">>, Props, true).
+
 
 add_default_text_field(Fields) ->
     DefaultFields = add_default_text_field(Fields, []),

--- a/src/mango_native_proc.erl
+++ b/src/mango_native_proc.erl
@@ -178,10 +178,10 @@ get_text_field_values(Values, TAcc) when is_list(Values) ->
             LengthFieldName = make_text_field_name(NewTAcc#tacc.path, <<"length">>),
             LengthField = [{LengthFieldName, <<"length">>, length(Values)}],
             get_text_field_values_arr(Values, NewTAcc, LengthField);
-
         _ ->
             get_text_field_values_arr(Values, NewTAcc, [])
     end;
+
 get_text_field_values(Bin, TAcc) when is_binary(Bin) ->
     make_text_field(TAcc, <<"string">>, Bin);
 

--- a/src/mango_native_proc.erl
+++ b/src/mango_native_proc.erl
@@ -149,9 +149,9 @@ get_text_entries({IdxProps}, Doc) ->
 
 get_text_entries0(IdxProps, Doc) ->
     DefaultEnabled = get_default_enabled(IdxProps),
-    Index_Array_Lengths = get_index_array_lengths(IdxProps),
+    IndexArrayLengths = get_index_array_lengths(IdxProps),
     FieldsList = get_text_field_list(IdxProps),
-    TAcc = #tacc{index_array_lengths = Index_Array_Lengths, fields = FieldsList},
+    TAcc = #tacc{index_array_lengths = IndexArrayLengths, fields = FieldsList},
     Fields0 = get_text_field_values(Doc, TAcc),
     Fields = if not DefaultEnabled -> Fields0; true ->
         add_default_text_field(Fields0)
@@ -165,10 +165,10 @@ get_text_field_values({Props}, TAcc) when is_list(Props) ->
     get_text_field_values_obj(Props, TAcc, []);
 
 get_text_field_values(Values, TAcc) when is_list(Values) ->
-    Index_Array_Lengths = TAcc#tacc.index_array_lengths,
+    IndexArrayLengths = TAcc#tacc.index_array_lengths,
     NewPath = ["[]" | TAcc#tacc.path],
-    NewTAcc = TAcc#tacc{index_array_lengths = Index_Array_Lengths, path = NewPath},
-    case Index_Array_Lengths of 
+    NewTAcc = TAcc#tacc{index_array_lengths = IndexArrayLengths, path = NewPath},
+    case IndexArrayLengths of 
         true ->
             % We bypass make_text_field and directly call make_text_field_name
             % because the length field name is not part of the path.
@@ -194,9 +194,9 @@ get_text_field_values(null, TAcc) ->
 get_text_field_values_obj([], _, FAcc) ->
     FAcc;
 get_text_field_values_obj([{Key, Val} | Rest], TAcc, FAcc) ->
-    Index_Array_Lengths = TAcc#tacc.index_array_lengths,
+    IndexArrayLengths = TAcc#tacc.index_array_lengths,
     NewPath = [Key | TAcc#tacc.path],
-    NewTAcc = TAcc#tacc{index_array_lengths = Index_Array_Lengths, path = NewPath},
+    NewTAcc = TAcc#tacc{index_array_lengths = IndexArrayLengths, path = NewPath},
     Fields = get_text_field_values(Val, NewTAcc),
     get_text_field_values_obj(Rest, TAcc, Fields ++ FAcc).
 


### PR DESCRIPTION
Basically following the same pattern as we did for default field. By
default the array length fields are enabled and this change allows us
to disable it by adding the following field in the design doc. 
index_array_lengths=false
This is a short term solution until we revisit the cloudant query design. See FB case 49429 and 54260 for further details.