### PR TITLE
Option to disable index array lengths

### DIFF
--- a/src/mango_idx_text.erl
+++ b/src/mango_idx_text.erl
@@ -197,6 +197,12 @@ opts() ->
             {optional, true},
             {default, []},
             {validator, fun ?MODULE:validate_fields/1}
+        ]},
+        {<<"index_array_lengths">>, [
+            {tag, index_array_lengths},
+            {optional, true},
+            {default, true},
+            {validator, fun mango_opts:is_boolean/1}
         ]}
     ].
 

--- a/src/mango_native_proc.erl
+++ b/src/mango_native_proc.erl
@@ -37,6 +37,7 @@
 
 
 -record(tacc, {
+    index_array_lengths = true,
     fields = all_fields,
     path = []
 }).
@@ -148,8 +149,12 @@ get_text_entries({IdxProps}, Doc) ->
 
 get_text_entries0(IdxProps, Doc) ->
     DefaultEnabled = get_default_enabled(IdxProps),
+    IndexArrayLengths = get_index_array_lengths(IdxProps),
     FieldsList = get_text_field_list(IdxProps),
-    TAcc = #tacc{fields = FieldsList},
+    TAcc = #tacc{
+        index_array_lengths = IndexArrayLengths,
+        fields = FieldsList
+    },
     Fields0 = get_text_field_values(Doc, TAcc),
     Fields = if not DefaultEnabled -> Fields0; true ->
         add_default_text_field(Fields0)
@@ -163,13 +168,19 @@ get_text_field_values({Props}, TAcc) when is_list(Props) ->
     get_text_field_values_obj(Props, TAcc, []);
 
 get_text_field_values(Values, TAcc) when is_list(Values) ->
+    IndexArrayLengths = TAcc#tacc.index_array_lengths,
     NewPath = ["[]" | TAcc#tacc.path],
     NewTAcc = TAcc#tacc{path = NewPath},
-    % We bypass make_text_field and directly call make_text_field_name
-    % because the length field name is not part of the path.
-    LengthFieldName = make_text_field_name(NewTAcc#tacc.path, <<"length">>),
-    LengthField = [{LengthFieldName, <<"length">>, length(Values)}],
-    get_text_field_values_arr(Values, NewTAcc, LengthField);
+    case IndexArrayLengths of 
+        true ->
+            % We bypass make_text_field and directly call make_text_field_name
+            % because the length field name is not part of the path.
+            LengthFieldName = make_text_field_name(NewTAcc#tacc.path, <<"length">>),
+            LengthField = [{LengthFieldName, <<"length">>, length(Values)}],
+            get_text_field_values_arr(Values, NewTAcc, LengthField);
+        _ ->
+            get_text_field_values_arr(Values, NewTAcc, [])
+    end;
 
 get_text_field_values(Bin, TAcc) when is_binary(Bin) ->
     make_text_field(TAcc, <<"string">>, Bin);
@@ -209,6 +220,10 @@ get_default_enabled(Props) ->
         {Opts}->
             couch_util:get_value(<<"enabled">>, Opts, true)
     end.
+
+
+get_index_array_lengths(Props) ->
+    couch_util:get_value(<<"index_array_lengths">>, Props, true).
 
 
 add_default_text_field(Fields) ->

--- a/test/10-disable-array-length-field-test.py
+++ b/test/10-disable-array-length-field-test.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import mango
+
+
+class DisableIndexArrayLengthsTest(mango.UserDocsTextTests):
+
+    @classmethod
+    def setUpClass(klass):
+        super(DisableIndexArrayLengthsTest, klass).setUpClass()
+        klass.db.create_text_index(ddoc="disable_index_array_lengths",
+                                   analyzer="keyword", index_array_lengths=False)
+        klass.db.create_text_index(ddoc="explicit_enable_index_array_lengths",
+                                   analyzer="keyword", index_array_lengths=True)
+
+    def test_disable_index_array_length(self):
+        docs = self.db.find({"favorites": {"$size": 4}},
+                            use_index="disable_index_array_lengths")
+        for d in docs:
+            assert len(d["favorites"]) == 0
+
+    def test_enable_index_array_length(self):
+        docs = self.db.find({"favorites": {"$size": 4}},
+                            use_index="explicit_enable_index_array_lengths")
+        for d in docs:
+            assert len(d["favorites"]) == 4

--- a/test/mango.py
+++ b/test/mango.py
@@ -102,7 +102,7 @@ class Database(object):
         return r.json()["result"] == "created"
 
     def create_text_index(self, analyzer=None, selector=None, idx_type="text",
-        default_field=None, fields=None, name=None, ddoc=None):
+        default_field=None, fields=None, name=None, ddoc=None,index_array_lengths=None):
         body = {
             "index": {
             },
@@ -115,6 +115,8 @@ class Database(object):
             body["index"]["default_analyzer"] = analyzer
         if default_field is not None:
             body["index"]["default_field"] = default_field
+        if index_array_lengths is not None:
+            body["index"]["index_array_lengths"] = index_array_lengths
         if selector is not None:
             body["selector"] = selector
         if fields is not None:


### PR DESCRIPTION
@davisp . I have started fresh again as I had to make additional changes so that the mango index service can play nice with the new field added to the index doc.
Have also added two new tests.
Please review these changes again and will deliver once I get a +1 from you. I will also make these changes in dbnext too. FYI @tonysun83 